### PR TITLE
Fixed multibyte characters division (and Slack 400 errors)

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -237,7 +237,7 @@ class SlackPlugin extends Plugin {
             'CONTROLEND'   => '>'
         ];
         // Replace the CONTROL characters, and limit text length to 500 characters.
-        return substr(str_replace(array_keys($moreformatter), array_values($moreformatter), $formatted_text), 0, 500);
+        return mb_substr(str_replace(array_keys($moreformatter), array_values($moreformatter), $formatted_text), 0, 500);
     }
 
     /**


### PR DESCRIPTION
I've recently noticed that some of the ticket submissions aren't sent to the slack.

I've noticed that in these cases I'm getting 400 curl error from slack. After further debugging I've noticed that `osticket-plugin` was trying to send an empty message there.

This was caused by encoding error silently thrown by json_encode, that was trying to encode incorrectly formatted utf-8 string.

Why there was an incorrectly formatted utf-8 string you may ask? Because of `substr` usage in `format_text` function that is limiting all messages sent to slack to 500 characters.

The problem is that `substr` is incorrectly handling multi-byte characters, that may be cut in half. If your ticket have had such multi-byte character around index 500 -> you've got an error.

Solution? Use `mb_substr` that should treat these string more gently, and don't them in half