### PR TITLE
Slack message type selection

### DIFF
--- a/config.php
+++ b/config.php
@@ -54,7 +54,8 @@ class SlackPluginConfig extends PluginConfig {
             'slack-update-types' => new ChoiceField([
                 'label'         => $__('Update Types'),
                 'hint'          => $__('What types of updates should be sent via Slack?'),
-                'choices'=> array('both' => 'New & Updated Tickets', 'updatesOnly' => 'Only Ticket Updates', 'newOnly' => 'Only New Tickets'),
+                'choices' => array('both' => 'New & Updated Tickets', 'updatesOnly' => 'Only Ticket Updates', 'newOnly' => 'Only New Tickets'),
+                'default' => 'both',
                 'configuration' => [
                     'size'   => 30,
                     'length' => 200

--- a/config.php
+++ b/config.php
@@ -51,6 +51,15 @@ class SlackPluginConfig extends PluginConfig {
                     'length' => 200
                 ],
                     ]),
+            'slack-update-types' => new ChoiceField([
+                'label'         => $__('Update Types'),
+                'hint'          => $__('What types of updates should be sent via Slack?'),
+                'choices'=> array('both' => 'New & Updated Tickets', 'updatesOnly' => 'Only Ticket Updates', 'newOnly' => 'Only New Tickets'),
+                'configuration' => [
+                    'size'   => 30,
+                    'length' => 200
+                ],
+                    ]),
             'message-template'           => new TextareaField([
                 'label'         => $__('Message Template'),
                 'hint'          => $__('The main text part of the Slack message, uses Ticket Variables, for what the user typed, use variable: %{slack_safe_message}'),


### PR DESCRIPTION
Enables plugin users to select what type of slack notifications they want to be sent. Either "onlyNew", "onlyUpdates" or "both". Previously, "both" was the only mode and so, is set as default.