### PR TITLE
Added & to presave function to resolve php8 error, ok for v1.16 but not v1.17

### DIFF
--- a/config.php
+++ b/config.php
@@ -20,7 +20,7 @@ class SlackPluginConfig extends PluginConfig {
         return Plugin::translate('slack');
     }
 
-    function pre_save($config, &$errors) {
+    function pre_save(&$config, &$errors) {
         if ($config['slack-regex-subject-ignore'] && false === @preg_match("/{$config['slack-regex-subject-ignore']}/i", null)) {
             $errors['err'] = 'Your regex was invalid, try something like "spam", it will become: "/spam/i" when we use it.';
             return FALSE;


### PR DESCRIPTION
This should enable the plugin for php8 with OsTicket v1.16 however there are issues still with v1.17.

With the changes to plugins in the current RC3 of OsTicket v1.17, there still remains an issue with reading settings for this plugin.

Some things work in the bootstrap function but not in other functions. This leads to an error about the SLACK_URL not being set when it actually is.